### PR TITLE
Correct Streamlit run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project showcases the capabilities of combining OpenAI's GPT-4 with Streaml
 
 1. **Run the Streamlit App**:
     ```bash
-    streamlit run main_app.py
+    streamlit run main_app_streamlit.py
     ```
 
 2. Open the displayed URL in your browser, usually `http://localhost:8501`.


### PR DESCRIPTION
Related to #2

Updates the command in the README.md file under the "Usage" section.

- Changes the command for running the Streamlit app from `streamlit run main_app.py` to `streamlit run main_app_streamlit.py` to reflect the correct filename and address user feedback.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NikhilSehgal123/Azure-OpenAI-SQL/issues/2?shareId=ceded85d-b3c1-4ba5-b639-bebe30970318).